### PR TITLE
upgrade vertx to 3.5.1

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+vertx-parent

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <annotationProcessing>
+      <profile name="Maven default annotation processors profile" enabled="true">
+        <sourceOutputDir name="target/generated-sources/annotations" />
+        <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />
+        <outputRelativeToContentRoot value="true" />
+        <module name="Vertx-AliveCheck" />
+        <module name="Vertx-Cluster" />
+        <module name="Vertx-Exampl-ITest" />
+        <module name="Vertx-Extended-Verticles" />
+        <module name="Vertx-Extender" />
+        <module name="Vertx-Feature" />
+        <module name="Vertx-Http" />
+        <module name="Vertx-Karaf" />
+        <module name="Vertx-Karaf-Cluster" />
+        <module name="Vertx-Karaf-Cluster-Docker" />
+        <module name="Vertx-Microservice-MetricsDashboard" />
+        <module name="Vertx-Microservices-Bookservice" />
+        <module name="Vertx-Microservices-Cluster-Docker" />
+        <module name="Vertx-Microservices-Cluster-Karaf" />
+        <module name="Vertx-Microservices-CookbookUI" />
+        <module name="Vertx-Microservices-Entity" />
+        <module name="Vertx-Microservices-Features" />
+        <module name="Vertx-Microservices-ITest" />
+        <module name="Vertx-Microservices-JDBC" />
+        <module name="Vertx-Microservices-Karaf" />
+        <module name="Vertx-Shell" />
+        <module name="Vertx-System" />
+        <module name="Vertx-Verticles" />
+      </profile>
+    </annotationProcessing>
+    <bytecodeTargetLevel>
+      <module name="Vertx-AliveCheck" target="1.8" />
+      <module name="Vertx-Cluster" target="1.8" />
+      <module name="Vertx-Exampl-ITest" target="1.8" />
+      <module name="Vertx-Extended-Verticles" target="1.8" />
+      <module name="Vertx-Extender" target="1.8" />
+      <module name="Vertx-Feature" target="1.8" />
+      <module name="Vertx-Http" target="1.8" />
+      <module name="Vertx-Karaf" target="1.8" />
+      <module name="Vertx-Karaf-Cluster" target="1.8" />
+      <module name="Vertx-Karaf-Cluster-Docker" target="1.8" />
+      <module name="Vertx-Microservice-MetricsDashboard" target="1.8" />
+      <module name="Vertx-Microservices" target="1.8" />
+      <module name="Vertx-Microservices-Bookservice" target="1.8" />
+      <module name="Vertx-Microservices-Cluster-Docker" target="1.8" />
+      <module name="Vertx-Microservices-Cluster-Karaf" target="1.8" />
+      <module name="Vertx-Microservices-CookbookUI" target="1.8" />
+      <module name="Vertx-Microservices-Entity" target="1.8" />
+      <module name="Vertx-Microservices-Features" target="1.8" />
+      <module name="Vertx-Microservices-ITest" target="1.8" />
+      <module name="Vertx-Microservices-JDBC" target="1.8" />
+      <module name="Vertx-Microservices-Karaf" target="1.8" />
+      <module name="vertx-parent" target="1.8" />
+      <module name="Vertx-Shell" target="1.8" />
+      <module name="Vertx-System" target="1.8" />
+      <module name="Vertx-Verticles" target="1.8" />
+    </bytecodeTargetLevel>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MavenProjectsManager">
+    <option name="originalFiles">
+      <list>
+        <option value="$PROJECT_DIR$/pom.xml" />
+      </list>
+    </option>
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_9" project-jdk-name="9.0" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/classes" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/Vertx-AliveCheck/Vertx-AliveCheck.iml" filepath="$PROJECT_DIR$/Vertx-AliveCheck/Vertx-AliveCheck.iml" />
+      <module fileurl="file://$PROJECT_DIR$/Vertx-Cluster/Vertx-Cluster.iml" filepath="$PROJECT_DIR$/Vertx-Cluster/Vertx-Cluster.iml" />
+      <module fileurl="file://$PROJECT_DIR$/Vertx-Exampl-ITest/Vertx-Exampl-ITest.iml" filepath="$PROJECT_DIR$/Vertx-Exampl-ITest/Vertx-Exampl-ITest.iml" />
+      <module fileurl="file://$PROJECT_DIR$/Vertx-Extended-Verticles/Vertx-Extended-Verticles.iml" filepath="$PROJECT_DIR$/Vertx-Extended-Verticles/Vertx-Extended-Verticles.iml" />
+      <module fileurl="file://$PROJECT_DIR$/Vertx-Extender/Vertx-Extender.iml" filepath="$PROJECT_DIR$/Vertx-Extender/Vertx-Extender.iml" />
+      <module fileurl="file://$PROJECT_DIR$/Vertx-Feature/Vertx-Feature.iml" filepath="$PROJECT_DIR$/Vertx-Feature/Vertx-Feature.iml" />
+      <module fileurl="file://$PROJECT_DIR$/Vertx-Http/Vertx-Http.iml" filepath="$PROJECT_DIR$/Vertx-Http/Vertx-Http.iml" />
+      <module fileurl="file://$PROJECT_DIR$/Vertx-Karaf/Vertx-Karaf.iml" filepath="$PROJECT_DIR$/Vertx-Karaf/Vertx-Karaf.iml" />
+      <module fileurl="file://$PROJECT_DIR$/Vertx-Karaf-Cluster/Vertx-Karaf-Cluster.iml" filepath="$PROJECT_DIR$/Vertx-Karaf-Cluster/Vertx-Karaf-Cluster.iml" />
+      <module fileurl="file://$PROJECT_DIR$/Vertx-Karaf-Cluster-Docker/Vertx-Karaf-Cluster-Docker.iml" filepath="$PROJECT_DIR$/Vertx-Karaf-Cluster-Docker/Vertx-Karaf-Cluster-Docker.iml" />
+      <module fileurl="file://$PROJECT_DIR$/Vertx-Microservices/Vertx-Microservice-MetricsDashboard/Vertx-Microservice-MetricsDashboard.iml" filepath="$PROJECT_DIR$/Vertx-Microservices/Vertx-Microservice-MetricsDashboard/Vertx-Microservice-MetricsDashboard.iml" />
+      <module fileurl="file://$PROJECT_DIR$/Vertx-Microservices/Vertx-Microservices.iml" filepath="$PROJECT_DIR$/Vertx-Microservices/Vertx-Microservices.iml" />
+      <module fileurl="file://$PROJECT_DIR$/Vertx-Microservices/Vertx-Microservices-Bookservice/Vertx-Microservices-Bookservice.iml" filepath="$PROJECT_DIR$/Vertx-Microservices/Vertx-Microservices-Bookservice/Vertx-Microservices-Bookservice.iml" />
+      <module fileurl="file://$PROJECT_DIR$/Vertx-Microservices/Vertx-Microservices-Cluster-Docker/Vertx-Microservices-Cluster-Docker.iml" filepath="$PROJECT_DIR$/Vertx-Microservices/Vertx-Microservices-Cluster-Docker/Vertx-Microservices-Cluster-Docker.iml" />
+      <module fileurl="file://$PROJECT_DIR$/Vertx-Microservices/Vertx-Microservices-Cluster-Karaf/Vertx-Microservices-Cluster-Karaf.iml" filepath="$PROJECT_DIR$/Vertx-Microservices/Vertx-Microservices-Cluster-Karaf/Vertx-Microservices-Cluster-Karaf.iml" />
+      <module fileurl="file://$PROJECT_DIR$/Vertx-Microservices/Vertx-Microservices-CookbookUI/Vertx-Microservices-CookbookUI.iml" filepath="$PROJECT_DIR$/Vertx-Microservices/Vertx-Microservices-CookbookUI/Vertx-Microservices-CookbookUI.iml" />
+      <module fileurl="file://$PROJECT_DIR$/Vertx-Microservices/Vertx-Microservices-Entity/Vertx-Microservices-Entity.iml" filepath="$PROJECT_DIR$/Vertx-Microservices/Vertx-Microservices-Entity/Vertx-Microservices-Entity.iml" />
+      <module fileurl="file://$PROJECT_DIR$/Vertx-Microservices/Vertx-Microservices-Features/Vertx-Microservices-Features.iml" filepath="$PROJECT_DIR$/Vertx-Microservices/Vertx-Microservices-Features/Vertx-Microservices-Features.iml" />
+      <module fileurl="file://$PROJECT_DIR$/Vertx-Microservices/Vertx-Microservices-ITest/Vertx-Microservices-ITest.iml" filepath="$PROJECT_DIR$/Vertx-Microservices/Vertx-Microservices-ITest/Vertx-Microservices-ITest.iml" />
+      <module fileurl="file://$PROJECT_DIR$/Vertx-Microservices/Vertx-Microservices-JDBC/Vertx-Microservices-JDBC.iml" filepath="$PROJECT_DIR$/Vertx-Microservices/Vertx-Microservices-JDBC/Vertx-Microservices-JDBC.iml" />
+      <module fileurl="file://$PROJECT_DIR$/Vertx-Microservices/Vertx-Microservices-Karaf/Vertx-Microservices-Karaf.iml" filepath="$PROJECT_DIR$/Vertx-Microservices/Vertx-Microservices-Karaf/Vertx-Microservices-Karaf.iml" />
+      <module fileurl="file://$PROJECT_DIR$/Vertx-Shell/Vertx-Shell.iml" filepath="$PROJECT_DIR$/Vertx-Shell/Vertx-Shell.iml" />
+      <module fileurl="file://$PROJECT_DIR$/Vertx-System/Vertx-System.iml" filepath="$PROJECT_DIR$/Vertx-System/Vertx-System.iml" />
+      <module fileurl="file://$PROJECT_DIR$/Vertx-Verticles/Vertx-Verticles.iml" filepath="$PROJECT_DIR$/Vertx-Verticles/Vertx-Verticles.iml" />
+      <module fileurl="file://$PROJECT_DIR$/vertx-parent.iml" filepath="$PROJECT_DIR$/vertx-parent.iml" />
+    </modules>
+  </component>
+</project>

--- a/Vertx-Exampl-ITest/src/test/java/de/nierbeck/example/vertx/test/VertxExtenderKarafTest.java
+++ b/Vertx-Exampl-ITest/src/test/java/de/nierbeck/example/vertx/test/VertxExtenderKarafTest.java
@@ -15,30 +15,10 @@
 */
 package de.nierbeck.example.vertx.test;
 
-import static org.junit.Assert.assertTrue;
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configureConsole;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
-
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.PrintStream;
-import java.util.Collection;
-import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.stream.Collectors;
-
-import javax.inject.Inject;
-
+import io.vertx.core.Verticle;
+import io.vertx.core.Vertx;
 import org.apache.karaf.features.BootFinished;
 import org.apache.karaf.features.FeaturesService;
-import org.apache.karaf.shell.api.console.Session;
-import org.apache.karaf.shell.api.console.SessionFactory;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Configuration;
@@ -53,8 +33,15 @@ import org.osgi.framework.ServiceReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.vertx.core.Verticle;
-import io.vertx.core.Vertx;
+import javax.inject.Inject;
+import java.io.File;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertTrue;
+import static org.ops4j.pax.exam.CoreOptions.maven;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.*;
 
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
@@ -80,7 +67,7 @@ public class VertxExtenderKarafTest {
 
     @Configuration
     // @formatter:off
-    public static Option[] configuration() throws Exception {
+    public static Option[] configuration() {
         return new Option[] {
                 karafDistributionConfiguration()
                         .frameworkUrl(

--- a/Vertx-Extender/src/main/java/de/nierbeck/example/vertx/extender/internal/VerticleObserver.java
+++ b/Vertx-Extender/src/main/java/de/nierbeck/example/vertx/extender/internal/VerticleObserver.java
@@ -15,14 +15,8 @@
 */
 package de.nierbeck.example.vertx.extender.internal;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.stream.Collector;
-import java.util.stream.Collectors;
-
+import io.vertx.core.Verticle;
 import org.ops4j.lang.NullArgumentException;
-import org.ops4j.pax.swissbox.core.BundleClassLoader;
 import org.ops4j.pax.swissbox.extender.BundleManifestScanner;
 import org.ops4j.pax.swissbox.extender.ManifestEntry;
 import org.ops4j.pax.swissbox.extender.ManifestFilter;
@@ -33,7 +27,10 @@ import org.osgi.framework.wiring.BundleWiring;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.vertx.core.Verticle;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class VerticleObserver {
 

--- a/Vertx-Microservices/Vertx-Microservices-ITest/src/test/java/de/nierbeck/example/vertx/microservices/test/AliveCheckInternalTest.java
+++ b/Vertx-Microservices/Vertx-Microservices-ITest/src/test/java/de/nierbeck/example/vertx/microservices/test/AliveCheckInternalTest.java
@@ -15,22 +15,11 @@
 */
 package de.nierbeck.example.vertx.microservices.test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configureConsole;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.features;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
-
-import java.io.File;
-
-import javax.inject.Inject;
-
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.apache.karaf.features.BootFinished;
 import org.apache.karaf.features.FeaturesService;
 import org.junit.BeforeClass;
@@ -38,7 +27,6 @@ import org.junit.Test;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Result;
 import org.junit.runner.RunWith;
-import org.junit.runner.notification.RunNotifier;
 import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.PaxExam;
@@ -46,11 +34,16 @@ import org.ops4j.pax.exam.karaf.options.LogLevelOption.LogLevel;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
 
-import io.vertx.core.Vertx;
-import io.vertx.core.eventbus.EventBus;
-import io.vertx.ext.unit.Async;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
+import javax.inject.Inject;
+import java.io.File;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.ops4j.pax.exam.CoreOptions.maven;
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.*;
 
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
@@ -73,7 +66,7 @@ public class AliveCheckInternalTest {
     BootFinished bootFinished;
 
     @Configuration
-    public Option[] configuration() throws Exception {
+    public Option[] configuration() {
         return new Option[] { karafDistributionConfiguration()
                 .frameworkUrl(
                             maven()
@@ -97,7 +90,7 @@ public class AliveCheckInternalTest {
 
 
     @Test
-    public void subRunner() throws Exception {
+    public void subRunner() {
         System.out.println("Calling sub-runner!!");
         Result result = JUnitCore.runClasses(SubTestWithRunner.class);
 //        assertThat(result.wasSuccessful(), is(true));
@@ -113,7 +106,7 @@ public class AliveCheckInternalTest {
     }
     
     @Test 
-    public void checkVertxNotNull() throws Exception {
+    public void checkVertxNotNull() {
         assertThat(vertxService, notNullValue());
     }
     
@@ -121,12 +114,12 @@ public class AliveCheckInternalTest {
     public static class SubTestWithRunner {
         
         @BeforeClass
-        public static void init() throws Exception {
+        public static void init() {
             System.out.println("Before test");
         }
         
         @Test
-        public void checkAliveCheckNavigable(TestContext context) throws Exception {
+        public void checkAliveCheckNavigable(TestContext context) {
             System.out.println("testing");
             Async async = context.async();
             System.out.println("vertxService: "+vertxService);

--- a/Vertx-Shell/src/main/java/de/nierbeck/example/vertx/shell/VertxServerList.java
+++ b/Vertx-Shell/src/main/java/de/nierbeck/example/vertx/shell/VertxServerList.java
@@ -16,25 +16,23 @@
  */
 package de.nierbeck.example.vertx.shell;
 
-import java.util.Map;
-import java.util.Map.Entry;
-
+import io.vertx.core.http.impl.HttpServerImpl;
+import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.net.impl.NetServerImpl;
+import io.vertx.core.net.impl.ServerID;
 import org.apache.karaf.shell.api.action.Command;
 import org.apache.karaf.shell.api.action.lifecycle.Service;
 import org.apache.karaf.shell.support.table.ShellTable;
 
-import io.vertx.core.http.impl.HttpServerImpl;
-import io.vertx.core.impl.VertxInternal;
-import io.vertx.core.net.impl.NetServerBase;
-import io.vertx.core.net.impl.NetServerImpl;
-import io.vertx.core.net.impl.ServerID;
+import java.util.Map;
+import java.util.Map.Entry;
 
 @Command(scope = "vertx", name = "netlist", description = "Lists all running Servers")
 @Service
 public class VertxServerList extends AbstractVertxCommand {
 
     @Override
-    public Object execute() throws Exception {
+    public Object execute() {
 
         ShellTable table = new ShellTable();
 
@@ -44,7 +42,7 @@ public class VertxServerList extends AbstractVertxCommand {
         table.column("Port");
         
         VertxInternal vertx = (VertxInternal) getVertxService();
-        for (Entry<ServerID, NetServerBase> server : vertx.sharedNetServers().entrySet()) {
+        for (Entry<ServerID, NetServerImpl> server : vertx.sharedNetServers().entrySet()) {
             table.addRow().addContent("", "X", server.getKey().host, server.getKey().port);
         }
         for (Map.Entry<ServerID, HttpServerImpl> server : vertx.sharedHttpServers().entrySet()) {

--- a/Vertx-System/src/main/java/de/nierbeck/example/vertx/VertxService.java
+++ b/Vertx-System/src/main/java/de/nierbeck/example/vertx/VertxService.java
@@ -16,25 +16,8 @@
  */
 package de.nierbeck.example.vertx;
 
-import static de.nierbeck.example.vertx.TcclSwitch.*;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.ServiceRegistration;
-import org.osgi.service.component.annotations.Activate;
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
-import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicy;
-
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.SharedMetricRegistries;
-
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.eventbus.EventBus;
@@ -42,6 +25,14 @@ import io.vertx.core.spi.VertxMetricsFactory;
 import io.vertx.core.spi.cluster.ClusterManager;
 import io.vertx.ext.dropwizard.DropwizardMetricsOptions;
 import io.vertx.ext.dropwizard.MetricsService;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.*;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static de.nierbeck.example.vertx.TcclSwitch.executeWithTCCLSwitch;
 
 @interface VertxConfig {
     int getWorkerPoolSize();
@@ -71,7 +62,7 @@ public class VertxService {
     private VertxConfig cfg;
 
     @Activate
-    public void start(BundleContext context, VertxConfig cfg) throws Exception {
+    public void start(BundleContext context, VertxConfig cfg) {
         LOGGER.info("Creating Vert.x instance");
         
         this.bundleContext = context;

--- a/pom.xml
+++ b/pom.xml
@@ -38,12 +38,14 @@
 	</modules>
 
 	<properties>
-		<vertx.version>3.4.2</vertx.version>
+
+		<vertx.version>3.5.1</vertx.version>
+		<netty.version>4.1.19.Final</netty.version>
+
 		<karaf.version>4.1.1</karaf.version>
 		<karaf.cellar.version>4.1.0</karaf.cellar.version>
 		<maven-bundle-plugin.version>3.0.1</maven-bundle-plugin.version>
 		<osgi.version>6.0.0</osgi.version>
-		<netty.version>4.1.8.Final</netty.version>
 		<kotlin.version>1.0.5-2</kotlin.version>
 		<pax.exam.version>4.11.0</pax.exam.version>
 		<pax.url.version>2.1.0</pax.url.version>


### PR DESCRIPTION
I am trying to upgrade to latest available vertx 3.5.1 

```
		<vertx.version>3.5.1</vertx.version>
		<netty.version>4.1.19.Final</netty.version>
```

IT stopped working (part of the build), any idea why?



